### PR TITLE
Shortcuts, node and npm reinstall, misc cleanup.

### DIFF
--- a/files/tools/server/public/loading-mmojo.html
+++ b/files/tools/server/public/loading-mmojo.html
@@ -56,7 +56,7 @@
     <body>
         <div id="loading">
             The model is loading. Please wait.<br/>
-            Mmojo Completion will appear soon.
+            Mmojo Complete will appear soon.
         </div>
     </body>
 </html>

--- a/instructions/101-Project-Goals.md
+++ b/instructions/101-Project-Goals.md
@@ -18,7 +18,7 @@ For developers, especially in the agent space, the OpenAI compatible API that ll
 
 I am not interested in squeezing out every ounce of performance out of particular CPUs or GPUs. The llama.cpp team has that covered. One funny thing that made llamafile more complicated than it needed to be was its focus on CPU inference optimization. It's funny because having to run on a wide range of x86 and ARM chips already took many effective CPU specific compiler optimizations off the table. And while the out-of-the-box Metal support on macOS was impressive, it made deploying llamafile for the first time cumbersome for macOS users who weren't developers.
 
-Most importantly to me, I created and maintain Mmojo Server to power my Mmojo Knowledge Appliance. Every feature in Mmojo Server is included because it makes the appliance better. There will be no unmaintainable fluff. My ability and willingness to say "No" will keep Mmojo Server a more usable and useful platform for you.""
+Most importantly to me, I created and maintain Mmojo Server to power my Mmojo Knowledge Appliance. Every feature in Mmojo Server is included because it makes the appliance better. There will be no unmaintainable fluff. My ability and willingness to say "No" will keep Mmojo Server a more usable and useful platform for you.
 
 ---
 ### Shortcuts and Automation

--- a/instructions/101-Project-Goals.md
+++ b/instructions/101-Project-Goals.md
@@ -24,7 +24,7 @@ Most importantly to me, I created and maintain Mmojo Server to power my Mmojo Kn
 ### Shortcuts and Automation
 The first developer criticism that Mmojo Server always gets is that it isn't automated enough. Guilty. Hear me out. Automation breaks. When it breaks, someone has to jump in and figure out what broke, then fix it, before anyone can use the automation again. The sequences of discrete automated steps in this repo, invoked manually do two things: (1) isolate what happens to be broken on any particular day, and (2) they foster understanding of each process from users of this repo. In a previous job, I spent ten years fighting against premature optimization that continually and expensively broke. I do not want that in my project.
 
-Having said that, many steps (or pages) in the instructions have "SHORTCUT" scripts at the end. After you've done a few builds end-to-end, you should try them out. I also plan to offer shortcut scripts for whole sections. I promise they will break spectacularly and often, because lots of stuff changes unexpectedly and often in upstream projects like llama.cpp. But if the section shortcuts work well most of the time, they'll be pretty valuable.
+Having said that, many steps (or pages) in the instructions have "SHORTCUT" scripts at the end. The shortcuts for a step are linked in the **About this Step** area at the top of the page for your convenience. After you've done a few builds end-to-end, you should try them out. I also plan to offer shortcut scripts for whole sections. I promise they will break spectacularly and often, because lots of stuff changes unexpectedly and often in upstream projects like llama.cpp. But if the section shortcuts work well most of the time, they'll be pretty valuable.
 
 ---
 ### Proceed

--- a/instructions/201-Prepare-WSL.md
+++ b/instructions/201-Prepare-WSL.md
@@ -85,6 +85,8 @@ Defaults        env_reset,timestamp_timeout=-1
 
 `Ctrl-X`, then `Y`, then `Enter` to save and exit.
 
+---
+### Power Off the WSL Instance
 Now, poweroff the WSL instance:
 ```
 sudo poweroff
@@ -122,6 +124,16 @@ Add it to the **Taskbar**.
 ### Launch MmojoServerBuild
 
 Launch and log into your new instance by clicking the icon you just added to the **Taskbar**.
+
+Now, let's get a `sudo` password in, so we don't have to enter it again this session.
+```
+sudo echo "Mmojo Server!"
+```
+
+You'll be prompted for your `sudo` password:
+```
+admin123!
+```
 
 ---
 ### Start from Scratch Often

--- a/instructions/203-Clone-Mmojo-Server-Repo.md
+++ b/instructions/203-Clone-Mmojo-Server-Repo.md
@@ -19,8 +19,10 @@ if [ "$MMOJO_SERVER_DIR" ]; then
 fi
 mkdir -p $MMOJO_SERVER_DIR
 git clone https://github.com/BradHutchings/mmojo-server.git $MMOJO_SERVER_DIR
+# update needs the variables.
 . $MMOJO_SERVER_SCRIPTS/mm-environment-variables.sh
 . $MMOJO_SERVER_SCRIPTS/mm-update-local-mmojo-server-repo.sh
+# update might change the variables.
 . mm-environment-variables.sh
 printf "\n**********\n*\n* FINISHED: Clone the Mmojo Server Repo.\n*\n**********\n\n"
 ```

--- a/instructions/203-Clone-Mmojo-Server-Repo.md
+++ b/instructions/203-Clone-Mmojo-Server-Repo.md
@@ -19,7 +19,7 @@ if [ "$MMOJO_SERVER_DIR" ]; then
 fi
 mkdir -p $MMOJO_SERVER_DIR
 git clone https://github.com/BradHutchings/mmojo-server.git $MMOJO_SERVER_DIR
-. mm-environment-variables.sh
+. $MMOJO_SERVER_SCRIPTS/mm-environment-variables.sh
 . $MMOJO_SERVER_SCRIPTS/mm-update-local-mmojo-server-repo.sh
 . mm-environment-variables.sh
 printf "\n**********\n*\n* FINISHED: Clone the Mmojo Server Repo.\n*\n**********\n\n"

--- a/instructions/203-Clone-Mmojo-Server-Repo.md
+++ b/instructions/203-Clone-Mmojo-Server-Repo.md
@@ -19,6 +19,7 @@ if [ "$MMOJO_SERVER_DIR" ]; then
 fi
 mkdir -p $MMOJO_SERVER_DIR
 git clone https://github.com/BradHutchings/mmojo-server.git $MMOJO_SERVER_DIR
+. mm-environment-variables.sh
 . $MMOJO_SERVER_SCRIPTS/mm-update-local-mmojo-server-repo.sh
 . mm-environment-variables.sh
 printf "\n**********\n*\n* FINISHED: Clone the Mmojo Server Repo.\n*\n**********\n\n"

--- a/instructions/203-Clone-Mmojo-Server-Repo.md
+++ b/instructions/203-Clone-Mmojo-Server-Repo.md
@@ -19,12 +19,17 @@ if [ "$MMOJO_SERVER_DIR" ]; then
 fi
 mkdir -p $MMOJO_SERVER_DIR
 git clone https://github.com/BradHutchings/mmojo-server.git $MMOJO_SERVER_DIR
+
 # mm-update-local-mmojo-server-repo.sh uses these variables, so set them first.
 . $MMOJO_SERVER_SCRIPTS/mm-environment-variables.sh
+
 # mm-update-local-mmojo-server-repo.sh copies mm- scripts to $HOME/mm-scripts
 . $MMOJO_SERVER_SCRIPTS/mm-update-local-mmojo-server-repo.sh
+
 # mm-update-local-mmojo-server-repo.sh might have changed the variables, so set them again.
+# This time, use the copy of the script in $HOME/mm-scripts
 . mm-environment-variables.sh
+
 printf "\n**********\n*\n* FINISHED: Clone the Mmojo Server Repo.\n*\n**********\n\n"
 ```
 

--- a/instructions/203-Clone-Mmojo-Server-Repo.md
+++ b/instructions/203-Clone-Mmojo-Server-Repo.md
@@ -19,10 +19,11 @@ if [ "$MMOJO_SERVER_DIR" ]; then
 fi
 mkdir -p $MMOJO_SERVER_DIR
 git clone https://github.com/BradHutchings/mmojo-server.git $MMOJO_SERVER_DIR
-# update needs the variables.
+# mm-update-local-mmojo-server-repo.sh uses these variables, so set them first.
 . $MMOJO_SERVER_SCRIPTS/mm-environment-variables.sh
+# mm-update-local-mmojo-server-repo.sh copies mm- scripts to $HOME/mm-scripts
 . $MMOJO_SERVER_SCRIPTS/mm-update-local-mmojo-server-repo.sh
-# update might change the variables.
+# mm-update-local-mmojo-server-repo.sh might have changed the variables, so set them again.
 . mm-environment-variables.sh
 printf "\n**********\n*\n* FINISHED: Clone the Mmojo Server Repo.\n*\n**********\n\n"
 ```

--- a/instructions/301-Download-Models.md
+++ b/instructions/301-Download-Models.md
@@ -6,6 +6,8 @@ If you already have models downloaded and copied to your Mmojo share, please pro
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**Shortcut:** [Scroll down](#shortcut-download-models).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/302-Copy-Models.md
+++ b/instructions/302-Copy-Models.md
@@ -4,6 +4,8 @@ In this step, we will copy models from the Mmojo Share.
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**Shortcut:** [Scroll down](#shortcut-copy-models).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/401-Prepare-to-Build.md
+++ b/instructions/401-Prepare-to-Build.md
@@ -5,6 +5,8 @@ In this step, we will clone this Mmojo-Server repo, fix problems that affect bui
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**Shortcut:** [Scroll down](#shortcut-run-all-the-above-scripts).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/401-Prepare-to-Build.md
+++ b/instructions/401-Prepare-to-Build.md
@@ -61,7 +61,9 @@ Customize the web UI, rebuild all the web files. If you did the **Suggested** st
 #### Uh. Oh. npm Spit Out Errors
 
 You may have an earlier version of `npm` and `nodejs` installed on your build machine than are required
-for that customization step. If you're running Linux or macOS, these steps should clean that up.
+for that customization step. If you're running Linux or macOS, these steps should clean that up. I am working
+to figure out if this it's safe to just put this in the [207. Install Dependencies](../207-Install-Dependencies.md)
+step.
 
 **ONLY RUN THESE IF YOU HAD PROBLEMS IN THE PREVIOUS STEP!!** Then rerun the previous step.
 ```

--- a/instructions/401-Prepare-to-Build.md
+++ b/instructions/401-Prepare-to-Build.md
@@ -60,10 +60,7 @@ Customize the web UI, rebuild all the web files. If you did the **Suggested** st
   ```
 #### Uh. Oh. npm Spit Out Errors
 
-You may have an earlier version of `npm` and `nodejs` installed on your build machine than are required
-for that customization step. If you're running Linux or macOS, these steps should clean that up. I am working
-to figure out if this it's safe to just put this in the [207. Install Dependencies](../207-Install-Dependencies.md)
-step.
+You may have an earlier version of `npm` and `nodejs` installed on your build machine than are required for that customization step. If you're running Linux or macOS, these steps should clean that up. This reinstall is already in this step: [207. Install Dependencies](207-Install-Dependencies.md). I'm leaving this workaround here until I'm sure it's not needed.
 
 **ONLY RUN THESE IF YOU HAD PROBLEMS IN THE PREVIOUS STEP!!** Then rerun the previous step.
 ```

--- a/instructions/401-Prepare-to-Build.md
+++ b/instructions/401-Prepare-to-Build.md
@@ -63,12 +63,10 @@ for that customization step. If you're running Linux or macOS, these steps shoul
 
 **ONLY RUN THESE IF YOU HAD PROBLEMS IN THE PREVIOUS STEP!!** Then rerun the previous step.
 ```
-cd ~
 sudo apt remove nodejs npm -y
 sudo apt install nodejs npm -y
 sudo npm install -g node@latest
 sudo npm install -g npm@latest
-cd ~/$BUILD_MMOJO_SERVER_DIR
 ```
 
 ---

--- a/instructions/403-Build-Debug.md
+++ b/instructions/403-Build-Debug.md
@@ -5,6 +5,8 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**Shortcut:** [Scroll down](#shortcut-build-debug-test).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/404-Build-APE.md
+++ b/instructions/404-Build-APE.md
@@ -6,7 +6,7 @@ The APE will run on x86 and ARM CPUs, and Windows, Linux, and macOS operating sy
 
 **Where:** Perform this step in either or both your x86_64 and your aarch64 (arm64) build environments. The resulting APE file will be copied to your Mmojo SMB share.
 
-**[Shortcut below](#shortcut-build-and-assemble-ape-copy-to-mmojo-share-test-ape).**
+**Shortcut:** [Scroll down](#shortcut-build-and-assemble-ape-copy-to-mmojo-share-test-ape).
 
 ---
 <details>

--- a/instructions/404-Build-APE.md
+++ b/instructions/404-Build-APE.md
@@ -6,6 +6,8 @@ The APE will run on x86 and ARM CPUs, and Windows, Linux, and macOS operating sy
 
 **Where:** Perform this step in either or both your x86_64 and your aarch64 (arm64) build environments. The resulting APE file will be copied to your Mmojo SMB share.
 
+**[Shortcut below](#shortcut-build-and-assemble-ape-copy-to-mmojo-share-test-ape).**
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/405-Build-CPU-Native.md
+++ b/instructions/405-Build-CPU-Native.md
@@ -5,7 +5,7 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
-**[Shortcut below](#shortcut-build-cpu-copy-to-mmojo-share-test).**
+**Shortcut:** [Scroll down](#shortcut-build-cpu-copy-to-mmojo-share-test).
 
 ---
 <details>

--- a/instructions/405-Build-CPU-Native.md
+++ b/instructions/405-Build-CPU-Native.md
@@ -5,6 +5,8 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**[Shortcut below](#shortcut-build-cpu-copy-to-mmojo-share-test).**
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/406-Build-CUDA.md
+++ b/instructions/406-Build-CUDA.md
@@ -5,6 +5,8 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**[Shortcut below](#shortcut-build-cuda-copy-to-mmojo-share-test).**
+
 **Note:** Compiler may complain about `-arch=native` in a Linux VM.
 
 <!--

--- a/instructions/406-Build-CUDA.md
+++ b/instructions/406-Build-CUDA.md
@@ -5,7 +5,7 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
-**[Shortcut below](#shortcut-build-cuda-copy-to-mmojo-share-test).**
+**Shortcut:** [Scroll down](#shortcut-build-cuda-copy-to-mmojo-share-test).
 
 **Note:** Compiler may complain about `-arch=native` in a Linux VM.
 

--- a/instructions/407-Build-Vulkan.md
+++ b/instructions/407-Build-Vulkan.md
@@ -5,7 +5,7 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
-**[Shortcut below](#shortcut-build-vulkan-copy-to-mmojo-share-test).**
+**Shortcut:** [Scroll down](#shortcut-build-vulkan-copy-to-mmojo-share-test).
 
 ---
 <details>

--- a/instructions/407-Build-Vulkan.md
+++ b/instructions/407-Build-Vulkan.md
@@ -5,6 +5,8 @@ In this step, we will build Mmojo Server (`mmojo-server`) for the CPU of your bu
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**[Shortcut below](#shortcut-build-vulkan-copy-to-mmojo-share-test).**
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/dogpile/401-Prepare-to-Build.md
+++ b/instructions/dogpile/401-Prepare-to-Build.md
@@ -57,12 +57,10 @@ for that customization step. If you're running Linux or macOS, these steps shoul
 
 **ONLY RUN THESE IF YOU HAD PROBLEMS IN THE PREVIOUS STEP!!** Then rerun the previous step.
 ```
-# cd ~
 sudo apt remove nodejs npm -y
 sudo apt install nodejs npm -y
 sudo npm install -g node@latest
 sudo npm install -g npm@latest
-# cd ~/$BUILD_MMOJO_SERVER_DIR
 ```
 
 ---

--- a/instructions/dogpile/401-Prepare-to-Build.md
+++ b/instructions/dogpile/401-Prepare-to-Build.md
@@ -55,7 +55,9 @@ Customize the web UI, rebuild all the web files.
 #### Uh. Oh. npm Spit Out Errors
 
 You may have an earlier version of `npm` and `nodejs` installed on your build machine than are required
-for that customization step. If you're running Linux or macOS, these steps should clean that up.
+for that customization step. If you're running Linux or macOS, these steps should clean that up. I am working
+to figure out if this it's safe to just put this in the [207. Install Dependencies](../207-Install-Dependencies.md)
+step.
 
 **ONLY RUN THESE IF YOU HAD PROBLEMS IN THE PREVIOUS STEP!!** Then rerun the previous step.
 ```

--- a/instructions/dogpile/401-Prepare-to-Build.md
+++ b/instructions/dogpile/401-Prepare-to-Build.md
@@ -8,6 +8,8 @@ In this step, we will clone the Mmojo-Server repo, fix problems that affect buil
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**Shortcut:** [Scroll down](#shortcut-run-all-the-above-scripts).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/dogpile/401-Prepare-to-Build.md
+++ b/instructions/dogpile/401-Prepare-to-Build.md
@@ -54,10 +54,7 @@ Customize the web UI, rebuild all the web files.
   ```
 #### Uh. Oh. npm Spit Out Errors
 
-You may have an earlier version of `npm` and `nodejs` installed on your build machine than are required
-for that customization step. If you're running Linux or macOS, these steps should clean that up. I am working
-to figure out if this it's safe to just put this in the [207. Install Dependencies](../207-Install-Dependencies.md)
-step.
+You may have an earlier version of `npm` and `nodejs` installed on your build machine than are required for that customization step. If you're running Linux or macOS, these steps should clean that up. This reinstall is already in this step: [207. Install Dependencies](../207-Install-Dependencies.md). I'm leaving this workaround here until I'm sure it's not needed.
 
 **ONLY RUN THESE IF YOU HAD PROBLEMS IN THE PREVIOUS STEP!!** Then rerun the previous step.
 ```

--- a/instructions/dogpile/403-Build-Debug.md
+++ b/instructions/dogpile/403-Build-Debug.md
@@ -10,6 +10,8 @@ In this step, we will build Dogpile (`dogpile`) for the CPU of your build enviro
 
 **Where:** Perform this step in both your x86_64 and your aarch64 (arm64) build environments.
 
+**Shortcut:** [Scroll down](#shortcut-build-debug-test).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/instructions/dogpile/404-Build-APE.md
+++ b/instructions/dogpile/404-Build-APE.md
@@ -161,7 +161,7 @@ $DOGPILE_SCRIPTS/404-Test-Cosmo-APE.sh
 
 ---
 ### Next Section
-- **Next Section:** [1500. Package Dogpile](1500-Package-Dogpile.md)
+- **Next Section:** [500. Package Dogpile](500-Package-Dogpile.md)
 
 ---
 [MIT License](/LICENSE)<br/>

--- a/instructions/dogpile/404-Build-APE.md
+++ b/instructions/dogpile/404-Build-APE.md
@@ -10,6 +10,8 @@ The APE will run on x86 and ARM CPUs, and Windows, Linux, and macOS operating sy
 
 **Where:** Perform this step in either or both your x86_64 and your aarch64 (arm64) build environments. The resulting APE file will be copied to your Mmojo SMB share.
 
+**Shortcut:** [Scroll down](#shortcut-build-and-assemble-ape-test-ape).
+
 ---
 <details>
   <summary><b>Update Local Mmojo Server Repo</b> &mdash; Expand if you haven't today.</summary>

--- a/scripts/207-Install-Dependencies.sh
+++ b/scripts/207-Install-Dependencies.sh
@@ -26,7 +26,15 @@ sudo apt install -y \
     python3 python3-pip python3-tk qt5-qmake qtbase5-dev \
     qtbase5-dev-tools qtcreator tk-dev wayland-protocols xz-utils \
     zip zlib1g-dev cifs-utils
-    
+
+echo ""
+echo "Reinstalling nodejs and npm because recompiling the current llama.cpp webui doesn't like what we have."
+
+sudo apt remove nodejs npm -y
+sudo apt install nodejs npm -y
+sudo npm install -g node@latest
+sudo npm install -g npm@latest
+
 printf "\n$STARS\n*\n* FINISHED: $SCRIPT_NAME.\n*\n$STARS\n\n"
 
 ################################################################################


### PR DESCRIPTION
- Each step (page) that has a shortcut on it, now has a link in the **About this Step** area to the shortcut. Please become familiar with the steps before you use shortcuts.
- Install Dependencies step now removes and reinstalls npm and node because the latest webui from llama.cpp requires that. This was a "fix it" script on the Prepare to Build step. I've left that there for the time being, and will remove it when the preemptove reinstall proves reliable.
- Misc cleanup since the big push this morning.