### PR TITLE
mm-mmojo-server

### DIFF
--- a/deploy/200-Windows-WSL/02-Prepare-WSL-Mmojo-Server.md
+++ b/deploy/200-Windows-WSL/02-Prepare-WSL-Mmojo-Server.md
@@ -183,7 +183,7 @@ echo $PATH
 ### Clone the Mmojo Server Repository
 The Mmojo Server Github repositort has scripts and tools for installing and building Mmojo Server.
 ```
-export MMOJO_SERVER_DIR="$HOME/200-mmojo-server"
+export MMOJO_SERVER_DIR="$HOME/mm-mmojo-server"
 export MMOJO_SERVER_SCRIPTS="$MMOJO_SERVER_DIR/scripts"
 cd $HOME
 if [ "$MMOJO_SERVER_DIR" ]; then

--- a/instructions/204-Clone-Mmojo-Server-Repo.md
+++ b/instructions/204-Clone-Mmojo-Server-Repo.md
@@ -11,7 +11,7 @@ As we work, we will update our local copy of the repo at the start of each secti
 
 Clone the Mmojo Server repo:
 ```
-export MMOJO_SERVER_DIR="$HOME/200-mmojo-server"
+export MMOJO_SERVER_DIR="$HOME/mm-mmojo-server"
 export MMOJO_SERVER_SCRIPTS="$MMOJO_SERVER_DIR/scripts"
 cd $HOME
 if [ "$MMOJO_SERVER_DIR" ]; then

--- a/scripts/mm-backup-models.sh
+++ b/scripts/mm-backup-models.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ################################################################################
-# This script backs up the models in the 400-MODELS directory to Mmojo Share.
-# It only backs up models that are not on the share.
+# This script backs up the models in the $HOME/mm-models directory to Mmojo 
+# Share. It only backs up models that are not on the share.
 #
 # See licensing note at end.
 ################################################################################

--- a/scripts/mm-clone-mmojo-server-repo.sh
+++ b/scripts/mm-clone-mmojo-server-repo.sh
@@ -10,7 +10,7 @@
 SCRIPT_NAME=$(basename -- "$0")
 printf "\n$STARS\n*\n* STARTED: $SCRIPT_NAME.\n*\n$STARS\n\n"
 
-# export MMOJO_SERVER_DIR="$HOME/200-mmojo-server"
+# export MMOJO_SERVER_DIR="$HOME/mm-mmojo-server"
 # export MMOJO_SERVER_SCRIPTS="$MMOJO_SERVER_DIR/scripts"
 cd $HOME
 if [ "$MMOJO_SERVER_DIR" ]; then

--- a/scripts/mm-clone-mmojo-server-repo.sh
+++ b/scripts/mm-clone-mmojo-server-repo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-# This script backs up the models in the 400-MODELS directory to Mmojo Share.
+# This script backs up the models in the $HOME/mm-models directory to Mmojo Share.
 # It only backs up models that are not on the share.
 #
 # See licensing note at end.

--- a/scripts/mm-environment-variables.sh
+++ b/scripts/mm-environment-variables.sh
@@ -28,7 +28,7 @@ export HOME_SCRIPTS="$HOME/mm-scripts"
 export TILDE_SCRIPTS="~/mm-scripts"
 
 echo "Setting mmojo-server paths."
-export MMOJO_SERVER_DIR="$HOME/200-mmojo-server"
+export MMOJO_SERVER_DIR="$HOME/mm-mmojo-server"
 export MMOJO_SERVER_FILES="$MMOJO_SERVER_DIR/files"
 export MMOJO_SERVER_SCRIPTS="$MMOJO_SERVER_DIR/scripts"
 

--- a/scripts/mm-environment-variables.sh
+++ b/scripts/mm-environment-variables.sh
@@ -73,13 +73,22 @@ if [ -e "$VULKAN_SETUP_ENV" ]; then
 fi
 
 echo "Setting Local and Share Models paths."
-export LOCAL_MODELS_DIR="$HOME/400-MODELS"
+export MOOELS_DIR_NAME="mm-models"
+
+export LOCAL_MODELS_DIR="$HOME/$MOOELS_DIR_NAME"
 export LOCAL_MODEL_MAP="$LOCAL_MODELS_DIR/model-map.txt"
 export LOCAL_DOWNLOAD_MODEL_MAP="$LOCAL_MODELS_DIR/download-model-map.txt"
 
-export MMOJO_SHARE_MODELS_DIR="$MMOJO_SHARE_MOUNT_POINT/models"
+export MMOJO_SHARE_MODELS_DIR="$MMOJO_SHARE_MOUNT_POINT/$MOOELS_DIR_NAME"
 export MMOJO_SHARE_MODEL_MAP="$MMOJO_SHARE_MODELS_DIR/model-map.txt"
 export MMOJO_SHARE_RESTORE_MODEL_MAP="$MMOJO_SHARE_MODELS_DIR/restore-model-map.txt"
+
+echo "Setting Local and Share Download paths."
+export DOWNLOADS_DIR_NAME="mm-downloads"
+
+export LOCAL_DOWNLOADS_DIR="$HOME/$DOWNLOADS_DIR_NAME"
+
+export MMOJO_SHARE_DOWNLOADS_DIR="$MMOJO_SHARE_MOUNT_POINT/$DOWNLOADS_DIR_NAME"
 
 echo "Setting Build paths."
 export BUILD_DIR="$HOME/500-BUILD-mmojo-server"

--- a/scripts/mm-restore-models.sh
+++ b/scripts/mm-restore-models.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 ################################################################################
-# This script restores models from the Mmojo Share to the 400-MODELS directory.
-# It only restores models listed in restore-model-map.txt on the Mmojo Share.
+# This script restores models from the Mmojo Share to the $HOME/mm-models
+# directory. It only restores models listed in restore-model-map.txt on the 
+# Mmojo Share.
 #
 # See licensing note at end.
 ################################################################################


### PR DESCRIPTION
- Changed directory of local clone of Mmojo Server repo to mm-mmojo-server. This is not fully tested, but the change breaks the bootstrapping code, so much push to main to test.

-Brad