### PR TITLE
Debugging output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Welcome to Mmojo Server version 3!
 
 This repository is the "Easy Button" for deploying and building [llama.cpp](https://github.com/ggml-org/llama.cpp) for your PC, laptop, or server. The audience for this repo is developers and tinkerers. Regular users can visit [Mmojo.net](https://mmojo.net) for Mmojo products meant for them.
 
+Get started here: [Deploy Mmojo Server to All Supported Platforms](/deploy/All-Supported-Platforms/README.md) guide.
+
 Mmojo Server is a private, local LLM server:
 - All defaults support private, local LLM usage. No logs by default. No cloud queries. No user accounts. No shared server over your network. Cues and completions &mdash; aka prompts and answers &mdash; do not leave your computer unless you make them leave your computer.
 - Mmojo Server sports a humane completion-style user interface as its default, and offers a traditional chat user interface for those who want that. You don't have to pretend to chat with a robot! 
@@ -19,11 +21,11 @@ This repository is your source for deploying and building Mmojo Server:
 The best path to start your Mmojo Server journey goes like this:
 1. Mmojo.net will host a downloadable Mmojo Stick package. Copy to a fast thumb drive. Use it on most dekstop or laptop computers in use today. Leave no footprints! There will be a link to that soon!
 2. Deploy Mmojo Server securely, tailored to:
-   - All Supported Platform using the [Deploy Mmojo Server to All Supported Platforms](/deploy/All-Supported-Platforms/README.md) recipe.
-   - Windows 11 using the [Deploy Mmojo Server on Windows (WSL)](/deploy/Windows-WSL/README.md) recipe.
-   - Debian Linux using the [Deploy Mmojo Server on Debian / Ubintu / Pi](/deploy/Debian-Ubuntu-Pi/README.md) recipe.
+   - All Supported Platform using the [Deploy Mmojo Server to All Supported Platforms](/deploy/All-Supported-Platforms/README.md) guide.
+   - Windows 11 using the [Deploy Mmojo Server on Windows (WSL)](/deploy/Windows-WSL/README.md) guide.
+   - Debian Linux using the [Deploy Mmojo Server on Debian / Ubintu / Pi](/deploy/Debian-Ubuntu-Pi/README.md) guide.
    - More platforms are coming soon.
-4. Get started with OpenClaw using the [OpenClaw (Windows WSL)](/deploy/OpenClaw-Windows-WSL/README.md) recipe.
+4. Get started with OpenClaw using the [OpenClaw (Windows WSL)](/deploy/OpenClaw-Windows-WSL/README.md) guide.
 
 Need professional help with your deployment, rollout, or build? Would you like to sponsor accessible, local, private LLMs? Email me!
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Welcome to Mmojo Server version 3!
 
 This repository is the "Easy Button" for deploying and building [llama.cpp](https://github.com/ggml-org/llama.cpp) for your PC, laptop, or server. The audience for this repo is developers and tinkerers. Regular users can visit [Mmojo.net](https://mmojo.net) for Mmojo products meant for them.
 
-Get started here: [Deploy Mmojo Server to All Supported Platforms](/deploy/All-Supported-Platforms/README.md) guide.
+**Get started here:** [Deploy Mmojo Server to All Supported Platforms](/deploy/All-Supported-Platforms/README.md) guide.
 
 Mmojo Server is a private, local LLM server:
 - All defaults support private, local LLM usage. No logs by default. No cloud queries. No user accounts. No shared server over your network. Cues and completions &mdash; aka prompts and answers &mdash; do not leave your computer unless you make them leave your computer.

--- a/files/common/arg-mmojo.cpp
+++ b/files/common/arg-mmojo.cpp
@@ -3818,6 +3818,24 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.use_mmap = true;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
+
+    // This is so we can show the prompt in regular output.
+    add_opt(common_arg(
+        {"--show-prompt"},
+        "show the prompt in regular output",
+        [](common_params & params) {
+            params.show_prompt = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+
+    // This is so we can show the completion in regular output.
+    add_opt(common_arg(
+        {"--show-completion"},
+        "show the completion in regular output",
+        [](common_params & params) {
+            params.show_completion = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
     // Mmojo Server END  
   
     return ctx_arg;

--- a/files/common/arg-mmojo.cpp
+++ b/files/common/arg-mmojo.cpp
@@ -3811,6 +3811,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
 
     // This is so we can override --no-mmap in default-args in APE file, turn mmap back on from command-line.
+    // This has been implemented (above). Commenting out for now, remove later. -Brad 2026-02-21
+    /*
     add_opt(common_arg(
         {"--mmap"},
         "use memory-map model, for overriding --no-mmap",
@@ -3818,7 +3820,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.use_mmap = true;
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
-
+    */
+  
     // This is so we can show the prompt in regular output.
     add_opt(common_arg(
         {"--show-prompt"},

--- a/files/common/common.h
+++ b/files/common/common.h
@@ -382,6 +382,8 @@ struct common_params {
     // This could be automated by searching for "int32_t n_batch " and inserting this block immediately below. -Brad 2025-11-05
     int32_t n_batch_sleep_ms          =     0; // delay in milliseconds after processing each batch.
     std::string default_ui_endpoint   =    ""; // endpoint for chat UI
+    bool    show_prompt               =    false;
+    bool    show_completion           =    false;
     // Mmojo Server END
 
     int32_t n_ubatch              =   512; // physical batch size for prompt processing (must be >=32 to use BLAS)

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3251,15 +3251,15 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         };
 
         if (!res->next) {
-            SRV_INF("!res->next, %s", "xxx");
+            // SRV_INF("!res->next, %s", "xxx");
             // Mmojo Server START
             if (params.show_completion) {
-                SRV_INF("\n----------\nCompletion:\n%s\n----------\n", res->data.c_str());
+                // SRV_INF("\n----------\nCompletion:\n%s\n----------\n", res->data.c_str());
             }
             // Mmojo Server END
         }
         else {
-            SRV_INF("res->next, %s", "zzz");
+            // SRV_INF("res->next, %s", "zzz");
         }
     }
 

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -1325,8 +1325,10 @@ private:
         SLT_DBG(slot, "n_decoded = %d, n_remaining = %d, next token: %5d '%s'\n", slot.n_decoded, slot.n_remaining, result.tok, token_str.c_str());
 
         // Mmojo Server START
-        if (params_base.show_completion) {
-            SRV_INF("\n----------\nCompletion:\n%s\n----------\n", slot.generated_text.c_str());
+        if (!slot.has_next_token) {
+            if (params_base.show_completion) {
+                SRV_INF("\n----------\nCompletion:\n%s\n----------\n", slot.generated_text.c_str());
+            }
         }
         // Mmojo Server END
 

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3046,6 +3046,12 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         // TODO: this log can become very long, put it behind a flag or think about a more compact format
         //SRV_DBG("Prompt: %s\n", prompt.is_string() ? prompt.get<std::string>().c_str() : prompt.dump(2).c_str());
 
+        // Mmojo Server START
+        if (params.show_prompt) {
+            SRV_INF("\n----------\nPrompt:\n%s\n----------\n", prompt.is_string() ? prompt.get<std::string>().c_str() : prompt.dump(2).c_str());
+        }
+        // Mmojo Server END
+
         // process prompt
         std::vector<server_tokens> inputs;
 

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3129,14 +3129,14 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 res->ok(arr[0]);
             } else {
                 // multi-results, non-OAI compat
-                res->ok(arr);
-              
-                // Mmojo Server START
-                if (params.show_prompt) {
-                    SRV_INF("\n----------\Completion:\n%s\n----------\n", arr.dump(0).c_str());
-                }
-                // Mmojo Server END
+                res->ok(arr);              
             }
+
+            // Mmojo Server START
+            if (params.show_prompt) {
+                SRV_INF("\n----------\Completion:\n%s\n----------\n", arr.dump(0).c_str());
+            }
+            // Mmojo Server END
         }
     } else {
         // in streaming mode, the first error must be treated as non-stream response

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3133,7 +3133,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             }
 
             // Mmojo Server START
-            if (params.show_prompt) {
+            if (params.show_completion) {
                 SRV_INF("\n----------\Completion:\n%s\n----------\n", arr.dump(0).c_str());
             }
             // Mmojo Server END

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -2557,12 +2557,7 @@ private:
                         slot.i_batch   = batch.n_tokens - 1;
 
                         SLT_INF(slot, "prompt done, n_tokens = %d, batch.n_tokens = %d\n", slot.prompt.n_tokens(), batch.n_tokens);
-
-                        // Mmojo Server START
-                        // This would be a good place to implement a --recap-prompts feature. Display the prompt and response here.
-                        // Do I know how to do that? Nope. -Brad 2026-02-17
-                        // Mmojo Server END
-
+                      
                         slot.init_sampler();
 
                         const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx), slot.id);
@@ -3185,6 +3180,13 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             try {
                 if (req.should_stop()) {
                     SRV_DBG("%s", "stopping streaming due to should_stop condition\n");
+                  
+                    // Mmojo Server START
+                    if (params.show_completion) {
+                        SRV_INF("\n----------\Completion:\n%s\n----------\n", res_this->data.c_str());
+                    }
+                    // Mmojo Server END
+                  
                     return false; // should_stop condition met
                 }
 
@@ -3211,6 +3213,13 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                             break;
                     }
                     SRV_DBG("%s", "all results received, terminating stream\n");
+                  
+                    // Mmojo Server START
+                    if (params.show_completion) {
+                        SRV_INF("\n----------\Completion:\n%s\n----------\n", res_this->data.c_str());
+                    }
+                    // Mmojo Server END
+
                     return false; // no more data, terminate
                 }
 
@@ -3219,6 +3228,13 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 if (result == nullptr) {
                     SRV_DBG("%s", "stopping streaming due to should_stop condition\n");
                     GGML_ASSERT(req.should_stop());
+                  
+                    // Mmojo Server START
+                    if (params.show_completion) {
+                        SRV_INF("\n----------\Completion:\n%s\n----------\n", res_this->data.c_str());
+                    }
+                    // Mmojo Server END
+                  
                     return false; // should_stop condition met
                 }
 

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3251,11 +3251,15 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         };
 
         if (!res->next) {
+            SRV_INF("!res->next, %s", "xxx");
             // Mmojo Server START
             if (params.show_completion) {
                 SRV_INF("\n----------\nCompletion:\n%s\n----------\n", res->data.c_str());
             }
             // Mmojo Server END
+        }
+        else {
+            SRV_INF("res->next, %s", "zzz");
         }
     }
 

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -1325,7 +1325,7 @@ private:
         SLT_DBG(slot, "n_decoded = %d, n_remaining = %d, next token: %5d '%s'\n", slot.n_decoded, slot.n_remaining, result.tok, token_str.c_str());
 
         // Mmojo Server START
-        if (params.show_completion) {
+        if (params_base.show_completion) {
             SRV_INF("\n----------\nCompletion:\n%s\n----------\n", slot.generated_text.c_str());
         }
         // Mmojo Server END

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3129,7 +3129,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
 
             // Mmojo Server START
             if (params.show_completion) {
-                SRV_INF("\n----------\Completion:\n%s\n----------\n", arr.dump(0).c_str());
+                SRV_INF("\n----------\nCompletion:\n%s\n----------\n", arr.dump(0).c_str());
             }
             // Mmojo Server END
         }
@@ -3179,14 +3179,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
 
             try {
                 if (req.should_stop()) {
-                    SRV_DBG("%s", "stopping streaming due to should_stop condition\n");
-                  
-                    // Mmojo Server START
-                    if (params.show_completion) {
-                        SRV_INF("\n----------\Completion:\n%s\n----------\n", res_this->data.c_str());
-                    }
-                    // Mmojo Server END
-                  
+                    SRV_DBG("%s", "stopping streaming due to should_stop condition\n");                  
                     return false; // should_stop condition met
                 }
 
@@ -3213,13 +3206,6 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                             break;
                     }
                     SRV_DBG("%s", "all results received, terminating stream\n");
-                  
-                    // Mmojo Server START
-                    if (params.show_completion) {
-                        SRV_INF("\n----------\Completion:\n%s\n----------\n", res_this->data.c_str());
-                    }
-                    // Mmojo Server END
-
                     return false; // no more data, terminate
                 }
 
@@ -3228,13 +3214,6 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 if (result == nullptr) {
                     SRV_DBG("%s", "stopping streaming due to should_stop condition\n");
                     GGML_ASSERT(req.should_stop());
-                  
-                    // Mmojo Server START
-                    if (params.show_completion) {
-                        SRV_INF("\n----------\Completion:\n%s\n----------\n", res_this->data.c_str());
-                    }
-                    // Mmojo Server END
-                  
                     return false; // should_stop condition met
                 }
 
@@ -3270,6 +3249,14 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 return false;
             }
         };
+
+        if (!res->next) {
+            // Mmojo Server START
+            if (params.show_completion) {
+                SRV_INF("\n----------\nCompletion:\n%s\n----------\n", res->data.c_str());
+            }
+            // Mmojo Server END
+        }
     }
 
     return res;

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -1324,6 +1324,12 @@ private:
 
         SLT_DBG(slot, "n_decoded = %d, n_remaining = %d, next token: %5d '%s'\n", slot.n_decoded, slot.n_remaining, result.tok, token_str.c_str());
 
+        // Mmojo Server START
+        if (params.show_completion) {
+            SRV_INF("\n----------\nCompletion:\n%s\n----------\n", slot.generated_text.c_str());
+        }
+        // Mmojo Server END
+
         return slot.has_next_token; // continue
     }
 
@@ -3126,12 +3132,6 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 // multi-results, non-OAI compat
                 res->ok(arr);              
             }
-
-            // Mmojo Server START
-            if (params.show_completion) {
-                SRV_INF("\n----------\nCompletion:\n%s\n----------\n", arr.dump(0).c_str());
-            }
-            // Mmojo Server END
         }
     } else {
         // in streaming mode, the first error must be treated as non-stream response
@@ -3249,18 +3249,6 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 return false;
             }
         };
-
-        if (!res->next) {
-            // SRV_INF("!res->next, %s", "xxx");
-            // Mmojo Server START
-            if (params.show_completion) {
-                // SRV_INF("\n----------\nCompletion:\n%s\n----------\n", res->data.c_str());
-            }
-            // Mmojo Server END
-        }
-        else {
-            // SRV_INF("res->next, %s", "zzz");
-        }
     }
 
     return res;

--- a/files/tools/server/server-context-mmojo.cpp
+++ b/files/tools/server/server-context-mmojo.cpp
@@ -3130,6 +3130,12 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             } else {
                 // multi-results, non-OAI compat
                 res->ok(arr);
+              
+                // Mmojo Server START
+                if (params.show_prompt) {
+                    SRV_INF("\n----------\Completion:\n%s\n----------\n", arr.dump(0).c_str());
+                }
+                // Mmojo Server END
             }
         }
     } else {

--- a/scripts/mm-build-for-platform.sh
+++ b/scripts/mm-build-for-platform.sh
@@ -122,6 +122,9 @@ if [ -d "$THIS_BUILD_DIR" ] && [ "$BUILD_SUBDIRECTORY" != "" ]; then
         -DCMAKE_VERBOSE_MAKEFILE=$VERBOSE $GGML_PARAMS $MMOJO_EXTRA_PARAMS
     cmake --build $BUILD_SUBDIRECTORY
 
+    echo
+    echo "Build command: cmake --build $BUILD_SUBDIRECTORY"
+    
     # Show off what we built
     printf "\nBuild of CPU Test of llama.cpp is complete.\n\n"
     printf "\$ ls -al $THIS_BUILD_DIR/$BUILD_SUBDIRECTORY/bin/\n"

--- a/scripts/mm-build-with-cosmo.sh
+++ b/scripts/mm-build-with-cosmo.sh
@@ -122,6 +122,9 @@ if [ -v CC ]; then
     # Build
     cmake --build $BUILD_SUBDIRECTORY --config Release
 
+    echo
+    echo "Build command: cmake --build $BUILD_SUBDIRECTORY" --config Release
+
     # Show off what we built
     printf "\nBuild of Cosmo $processor of llama.cpp is complete.\n\n"
     printf "\$ ls -al $THIS_BUILD_DIR/$BUILD_SUBDIRECTORY/bin/\n"

--- a/scripts/mm-build-with-cosmo.sh
+++ b/scripts/mm-build-with-cosmo.sh
@@ -123,7 +123,7 @@ if [ -v CC ]; then
     cmake --build $BUILD_SUBDIRECTORY --config Release
 
     echo
-    echo "Build command: cmake --build $BUILD_SUBDIRECTORY" --config Release
+    echo "Build command: cmake --build $BUILD_SUBDIRECTORY --config Release"
 
     # Show off what we built
     printf "\nBuild of Cosmo $processor of llama.cpp is complete.\n\n"

--- a/scripts/mm-prepare-patch-llama-cpp.sh
+++ b/scripts/mm-prepare-patch-llama-cpp.sh
@@ -12,17 +12,16 @@ printf "\n$STARS\n*\n* STARTED: $SCRIPT_NAME $1.\n*\n$STARS\n\n"
 
 cd $HOME
 
-THIS_BUILD_DIR=$BUILD_DIR
 EXECUTABLE_FILE=$PACKAGE_MMOJO_SERVER_FILE
 
 echo "  executable file: $EXECUTABLE_FILE"
-echo "       cloning in: $THIS_BUILD_DIR"
+echo "       cloning in: $BUILD_DIR"
 echo ""
 
 # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
-cp -r $MMOJO_SERVER_FILES/* $THIS_BUILD_DIR/
+cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
 
-cd $THIS_BUILD_DIR
+cd $BUILD_DIR
 
 #-------------------------------------------------------------------------------
 # Cosmo compatibility

--- a/scripts/mm-repo-branch-main.sh
+++ b/scripts/mm-repo-branch-main.sh
@@ -38,7 +38,7 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
       # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
       cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
       # In tools/server .cpp files, replace "defer(" with "defer_task(" to make Cosmo STL happy.
-      sed -i -e 's/defer(/defer_task(/g' tools/server/server-context-mmojo.cpp
+      sed -i -e 's/defer(/defer_task(/g' "$BUILD_DIR/tools/server/server-context-mmojo.cpp"
   fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."

--- a/scripts/mm-repo-branch-main.sh
+++ b/scripts/mm-repo-branch-main.sh
@@ -34,9 +34,11 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
   cp $MMOJO_SERVER_SCRIPTS/mr-*.sh $HOME_SCRIPTS
   chmod a+x $HOME_SCRIPTS/mr-*.sh
 
-  # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
   if [ -d "$BUILD_DIR" ]; then
+      # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
       cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
+      # In tools/server .cpp files, replace "defer(" with "defer_task(" to make Cosmo STL happy.
+      sed -i -e 's/defer(/defer_task(/g' tools/server/server-context-mmojo.cpp
   fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."

--- a/scripts/mm-repo-branch-main.sh
+++ b/scripts/mm-repo-branch-main.sh
@@ -33,6 +33,11 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
 
   cp $MMOJO_SERVER_SCRIPTS/mr-*.sh $HOME_SCRIPTS
   chmod a+x $HOME_SCRIPTS/mr-*.sh
+
+  # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
+  if [ -d "$BUILD_DIR" ]; then
+      cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
+  fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."
 fi

--- a/scripts/mm-repo-branch-work-in-progress.sh
+++ b/scripts/mm-repo-branch-work-in-progress.sh
@@ -38,7 +38,7 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
       # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
       cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
       # In tools/server .cpp files, replace "defer(" with "defer_task(" to make Cosmo STL happy.
-      sed -i -e 's/defer(/defer_task(/g' tools/server/server-context-mmojo.cpp
+      sed -i -e 's/defer(/defer_task(/g' "$BUILD_DIR/tools/server/server-context-mmojo.cpp"
   fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."

--- a/scripts/mm-repo-branch-work-in-progress.sh
+++ b/scripts/mm-repo-branch-work-in-progress.sh
@@ -34,9 +34,11 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
   cp $MMOJO_SERVER_SCRIPTS/mr-*.sh $HOME_SCRIPTS
   chmod a+x $HOME_SCRIPTS/mr-*.sh
 
-  # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
   if [ -d "$BUILD_DIR" ]; then
+      # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
       cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
+      # In tools/server .cpp files, replace "defer(" with "defer_task(" to make Cosmo STL happy.
+      sed -i -e 's/defer(/defer_task(/g' tools/server/server-context-mmojo.cpp
   fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."

--- a/scripts/mm-repo-branch-work-in-progress.sh
+++ b/scripts/mm-repo-branch-work-in-progress.sh
@@ -33,6 +33,11 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
 
   cp $MMOJO_SERVER_SCRIPTS/mr-*.sh $HOME_SCRIPTS
   chmod a+x $HOME_SCRIPTS/mr-*.sh
+
+  # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
+  if [ -d "$BUILD_DIR" ]; then
+      cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
+  fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."
 fi

--- a/scripts/mm-repo-update-local.sh
+++ b/scripts/mm-repo-update-local.sh
@@ -32,6 +32,11 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
 
   cp $MMOJO_SERVER_SCRIPTS/mr-*.sh $HOME_SCRIPTS
   chmod a+x $HOME_SCRIPTS/mr-*.sh
+
+  # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
+  if [ -d "$BUILD_DIR" ]; then
+      cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
+  fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."
 fi

--- a/scripts/mm-repo-update-local.sh
+++ b/scripts/mm-repo-update-local.sh
@@ -37,7 +37,7 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
       # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
       cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
       # In tools/server .cpp files, replace "defer(" with "defer_task(" to make Cosmo STL happy.
-      sed -i -e 's/defer(/defer_task(/g' tools/server/server-context-mmojo.cpp
+      sed -i -e 's/defer(/defer_task(/g' "$BUILD_DIR/tools/server/server-context-mmojo.cpp"
   fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."

--- a/scripts/mm-repo-update-local.sh
+++ b/scripts/mm-repo-update-local.sh
@@ -33,9 +33,11 @@ if [ -d "$MMOJO_SERVER_DIR" ]; then
   cp $MMOJO_SERVER_SCRIPTS/mr-*.sh $HOME_SCRIPTS
   chmod a+x $HOME_SCRIPTS/mr-*.sh
 
-  # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
   if [ -d "$BUILD_DIR" ]; then
+      # This copies the $MMOJO_SERVER_FILES tree into the $BUILD_DIR tree.
       cp -r $MMOJO_SERVER_FILES/* $BUILD_DIR/
+      # In tools/server .cpp files, replace "defer(" with "defer_task(" to make Cosmo STL happy.
+      sed -i -e 's/defer(/defer_task(/g' tools/server/server-context-mmojo.cpp
   fi
 else
   echo "The $MMOJO_SERVER_DIR directory does not exist."


### PR DESCRIPTION
- Added two flags: `--show-prompt` and `show-completion`. These show the prompt the server receives and the completion generated respectively in the regular output of `mmojo-server`. This is useful for app debugging if your app doesn't have easy output for these things. See OpenClaw.
- Additions to the repo scripts to make it easier to build without starting from scratch after updating the local repo.
- Removed my implementation of `--mmap` since llama.cpp now has one of its own.

-Brad